### PR TITLE
Initial refToHTML implementation

### DIFF
--- a/packages/jats/ref/RefComponent.js
+++ b/packages/jats/ref/RefComponent.js
@@ -1,18 +1,17 @@
 'use strict';
 
 var Component = require('substance/ui/Component');
-var TextPropertyEditor = require('substance/ui/TextPropertyEditor');
-var ContainerEditor = require('substance/ui/ContainerEditor');
+var refToHTML = require('./refToHTML');
+
 
 function RefComponent() {
   RefComponent.super.apply(this, arguments);
 }
 
 RefComponent.Prototype = function() {
-
   this.render = function($$) {
     var el = $$('div').addClass('sc-ref');
-    el.innerHTML = this.props.node.xmlContent;
+    el.html(refToHTML(this.props.node.xmlContent));
     return el;
   };
 };

--- a/packages/jats/ref/refToHTML.js
+++ b/packages/jats/ref/refToHTML.js
@@ -1,0 +1,164 @@
+var DOMElement = require('substance/ui/DefaultDOMElement');
+
+var namesToHTML = function (ref) {
+  var nameElements = ref.findAll('name');
+  var nameEls = [];
+  for (var i = 0; i < nameElements.length; i++) {
+    var name = nameElements[i];
+    var nameEl = DOMElement.createElement('span');
+    nameEl.addClass('name');
+
+    nameEl.text(name.find('surname').text() + ' ' + name.find('given-names').text());
+    if (i > 0 && i < nameElements.length) {
+      var comma = DOMElement.createElement('span');
+      comma.text(', ');
+      nameEls.push(comma);
+    }
+    nameEls.push(nameEl);
+  }
+
+  return nameEls;
+};
+
+var titleToHTML = function (ref) {
+  var articleTitle = ref.find('article-title');
+  var title = DOMElement.createElement('div');
+  title.addClass('title');
+
+  if (articleTitle) {
+    title.text(articleTitle.text() + '. ');
+  } else {
+    title.text('Untitled. ');
+  }
+
+  return title;
+};
+
+var metaToHTML = function (ref) {
+
+  // Example: "Cellular and Molecular Life Sciences, 70: 2657-2675, 2013"
+
+  var meta = DOMElement.createElement('div');
+
+  meta.addClass('meta');
+
+  var metaText = '';
+
+  var source = ref.find('source');
+  if (source) metaText += source.text() + ', ';
+
+  var volume = ref.find('volume');
+  if (volume) metaText += volume.text() + ': ';
+
+  var fpage = ref.find('fpage');
+  if (fpage) metaText += fpage.text() + '-';
+
+  var lpage = ref.find('lpage');
+  if (lpage) metaText += lpage.text() + ', ';
+
+  var year = ref.find("year");
+  if (year) metaText += year.text();
+
+  meta.text(metaText);
+  return meta;
+};
+
+var URItoHTML = function (ref) {
+  var el = DOMElement.createElement('div');
+  el.addClass('doi');
+
+  var doi = ref.find("pub-id[pub-id-type='doi'], ext-link[ext-link-type='doi']");
+  var uri = ref.find("ext-link[ext-link-type='uri']");
+
+  var url;
+
+  if (doi) {
+    url = 'http://dx.doi.org/' + doi.text();
+  } else if (uri) {
+    url = uri.getAttribute('xlink:href');
+  }
+
+  el.appendChild(DOMElement.createElement('a').setAttribute('href', url).text(url));
+  return el;
+};
+
+var refToHTML = function (ref) {
+
+  // ref element to HTML - https://jats.nlm.nih.gov/archiving/tag-library/0.4/n-ac60.html
+  // ------------------
+  // NLM XML example element-citation:
+  //
+  // <ref id="bib56">
+  //     <element-citation publication-type="journal">
+  //         <person-group person-group-type="author">
+  //             <name>
+  //                 <surname>Weinhold</surname>
+  //                 <given-names>A</given-names>
+  //             </name>
+  //             <name>
+  //                 <surname>Baldwin</surname>
+  //                 <given-names>IT</given-names>
+  //             </name>
+  //         </person-group>
+  //         <year>2011</year>
+  //         <article-title>Trichome-derived O-acyl sugars are a first meal for caterpillars that tags them for predation</article-title>
+  //         <source>Proc Natl Acad Sci U S A</source>
+  //         <volume>108</volume>
+  //         <fpage>7855</fpage>
+  //         <lpage>7859</lpage>
+  //         <ext-link ext-link-type="uri" xlink:href="http://dx.doi.org/10.1073/pnas.1101306108">10.1073/pnas.1101306108</ext-link>
+  //     </element-citation>
+  // </ref>
+
+  // NLM XML example mixed-citation:
+  // <ref id="bib2">
+  //   <mixed-citation publication-type="journal">
+  //       <person-group person-group-type="author">
+  //           <name>
+  //               <surname>Im</surname>
+  //               <given-names>JT</given-names>
+  //           </name>
+  //           <name>
+  //               <surname>Park</surname>
+  //               <given-names>BY</given-names>
+  //           </name>
+  //       </person-group>.
+  //       <year>2013</year>.
+  //       <article-title>Giant epidermal cyst on posterior scalp</article-title>.
+  //       <source>Arch Plast Surg</source>.
+  //       <volume>40</volume>
+  //       <fpage>280</fpage>-
+  //       <lpage>2</lpage>
+  //       <pub-id pub-id-type="doi">10.5999/aps.2013.40.3.280</pub-id>
+  //   </mixed-citation>
+  // </ref>
+
+  ref = DOMElement.parseXML(ref);
+
+  // TODO: remove safeguard for multiple citation elements
+  if(Array.isArray(ref)) {
+    ref = ref[0];
+  }
+
+  var el = DOMElement.createElement('div');
+
+  if (ref.is('mixed-citation') || ref.is('element-citation')) {
+    el.appendChild(titleToHTML(ref));
+    var names = namesToHTML(ref);
+
+    for (var i = 0; i < names.length; i++) {
+      el.appendChild(names[i]);
+    }
+
+    el.appendChild(metaToHTML(ref));
+
+    el.appendChild(URItoHTML(ref));
+  } else {
+    el.text('Citation type is unsupported');
+  }
+
+  return el.outerHTML;
+
+};
+
+module.exports = refToHTML;


### PR DESCRIPTION
First go (and no styling, I leave this to you, styling experts) :)

What we perhaps could do is to assemble an in-between CSL JSON, and use something like Citeproc.js to convert to HTML. That might be a bit more robust still.

![image](https://cloud.githubusercontent.com/assets/238667/16419064/a420bea6-3d4c-11e6-86f8-a9d103c7313a.png)




